### PR TITLE
Extend lifetime of login token

### DIFF
--- a/sample-website/Forum.php
+++ b/sample-website/Forum.php
@@ -57,6 +57,7 @@ class Forum
         $data = [
             'identification' => $username,
             'password' => $password,
+            'lifetime' => 2592000 // 60*60*24*30
         ];
 
         $response = $this->sendPostRequest('/api/token', $data);

--- a/sample-website/Forum.php
+++ b/sample-website/Forum.php
@@ -17,17 +17,17 @@ class Forum
      * @param $username
      * @param $email
      */
-    public function login($username, $email)
+    public function login($username, $email, $lifetime = 1209600 /* 60*60*24*14 */)
     {
         $password = $this->createPassword($username);
-        $token = $this->getToken($username, $password);
+        $token = $this->getToken($username, $password, $lifetime);
 
         if (empty($token)) {
             $this->signup($username, $password, $email);
-            $token = $this->getToken($username, $password);
+            $token = $this->getToken($username, $password, $lifetime);
         }
 
-        $this->setRememberMeCookie($token);
+        $this->setRememberMeCookie($token, $lifetime);
     }
 
     /**
@@ -52,12 +52,12 @@ class Forum
         return hash('sha256', $username . $this->config['password_token']);
     }
 
-    private function getToken($username, $password)
+    private function getToken($username, $password, $lifetime)
     {
         $data = [
             'identification' => $username,
             'password' => $password,
-            'lifetime' => 2592000 // 60*60*24*30
+            'lifetime' => $lifetime
         ];
 
         $response = $this->sendPostRequest('/api/token', $data);
@@ -102,9 +102,9 @@ class Forum
         return json_decode($result, true);
     }
 
-    private function setRememberMeCookie($token)
+    private function setRememberMeCookie($token, $lifetime)
     {
-        $this->setCookie(self::REMEMBER_ME_KEY, $token, strtotime('+30 days'));
+        $this->setCookie(self::REMEMBER_ME_KEY, $token, time() + $lifetime);
     }
 
     private function removeRememberMeCookie()


### PR DESCRIPTION
Your code sets the flarum_remember cookie to +30 days, which is fine, but inside flarum the default lifetime for a token is 3600 (seconds? if so, one hour). I've made changes to provide the lifetime parameter and also set it to `60 * 60 * 24 * 30` (= 30 days?). (see [this line](https://github.com/flarum/core/blob/v0.1.0-beta.6/src/Api/Controller/TokenController.php#L60) in flarums code for beta v6)